### PR TITLE
feat: Add global network option to pods

### DIFF
--- a/provider/pod.go
+++ b/provider/pod.go
@@ -28,6 +28,7 @@ type Pod struct {
 	DockerArgs              string      `pulumi:"dockerArgs"`
 	DockerId                string      `pulumi:"dockerId"`
 	Env                     []string    `pulumi:"env,optional"`
+	GlobalNetwork           bool        `pulumi:"globalNetwork,optional"`
 	GpuCount                int         `pulumi:"gpuCount"`
 	GpuPowerLimitPercent    int         `pulumi:"gpuPowerLimitPercent"`
 	Gpus                    []Gpu       `pulumi:"gpus,optional"`
@@ -74,6 +75,7 @@ type PodArgs struct {
 	DeployCost      float64           `pulumi:"deployCost,optional" structs:"deployCost,omitempty"`
 	DockerArgs      string            `pulumi:"dockerArgs,optional" structs:"dockerArgs,omitempty"`
 	Env             []PodEnv          `pulumi:"env,optional" structs:"env,omitempty"`
+	GlobalNetwork   bool              `pulumi:"globalNetwork,optional" structs:"globalNetwork,omitempty"`
 	GpuCount        int               `pulumi:"gpuCount" structs:"gpuCount,omitempty"`
 	GpuTypeId       string            `pulumi:"gpuTypeId" structs:"gpuTypeId,omitempty"`
 	GpuTypeIdList   []string          `pulumi:"gpuTypeIdList,optional" structs:"gpuTypeIdList,omitempty"`
@@ -161,6 +163,7 @@ func (*Pod) Create(ctx p.Context, name string, input PodArgs, preview bool) (str
 			$deployCost: Float
 			$dockerArgs: String
 			$env: [EnvironmentVariableInput]
+			$globalNetwork: Boolean
 			$gpuCount: Int
 			$gpuTypeId: String
 			$gpuTypeIdList: [String]
@@ -195,6 +198,7 @@ func (*Pod) Create(ctx p.Context, name string, input PodArgs, preview bool) (str
 				deployCost: $deployCost,
 				dockerArgs: $dockerArgs,
 				env: $env,
+				globalNetwork: $globalNetwork,
 				gpuCount: $gpuCount,
 				gpuTypeId: $gpuTypeId,
 				gpuTypeIdList: $gpuTypeIdList,

--- a/provider/schema.json
+++ b/provider/schema.json
@@ -222,6 +222,9 @@
                     },
                     "type": "array"
                 },
+                "globalNetwork": {
+                    "type": "boolean"
+                },
                 "gpuCount": {
                     "type": "integer"
                 },
@@ -325,6 +328,9 @@
                         "$ref": "#/types/runpod:index:PodEnv"
                     },
                     "type": "array"
+                },
+                "globalNetwork": {
+                    "type": "boolean"
                 },
                 "gpuCount": {
                     "type": "integer"
@@ -691,6 +697,9 @@
                         "type": "string"
                     },
                     "type": "array"
+                },
+                "globalNetwork": {
+                    "type": "boolean"
                 },
                 "gpuCount": {
                     "type": "integer"


### PR DESCRIPTION
Full disclosure, I haven't done any work on Pulumi providers in the past, so I'm not sure that these changes are all that's needed to support the new Global Network feature. I was told in Discord that the `podFindAndDeployOnDemand` mutation has a `globalNetwork` boolean available even though that isn't present in the GraphQL spec yet. I'm hoping that this is at least a good starting point to enable Global Network even if it's not perfect. 

Let me know if there are other changes that are needed. Thanks! 

Closes https://github.com/runpod/pulumi-runpod-native/issues/15 