### PR TITLE
SLS-238: pin runpod/pytorch refs to existing tag

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -67,7 +67,7 @@ const myRandomPod = new runpod.Pod("myRandomPod", {
   minMemoryInGb: 15,
   gpuTypeId: "NVIDIA GeForce RTX 4090",
   name: "RunPod Pytorch",
-  imageName: "runpod/pytorch:latest",
+  imageName: "runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04",
   dockerArgs: "",
   ports: "8888/http",
   volumeMountPath: "/workspace",

--- a/examples/nodejs/index.ts
+++ b/examples/nodejs/index.ts
@@ -40,7 +40,7 @@ const myRandomPod = new runpod.Pod("myRandomPod", {
   minMemoryInGb: 15,
   gpuTypeId: "NVIDIA GeForce RTX 4090",
   name: "RunPod Pytorch",
-  imageName: "runpod/pytorch:latest",
+  imageName: "runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04",
   dockerArgs: "",
   ports: "8888/http",
   volumeMountPath: "/workspace",


### PR DESCRIPTION
## Summary

SLS-8 flipped Layer 2 image verification to `enforce`. Pod-creates that reference a tag returning 404 now hard-fail at creation time. The `runpod/pytorch:latest` tag 404s, so example and docs code that tells customers to use it will fail on pod-create.

This pins those references to an existing tag.

## Change

`runpod/pytorch:latest` -> `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04`

Files:
- `docs/_index.md`
- `examples/nodejs/index.ts`

## Ref

SLS-238